### PR TITLE
feat(widget): Add new System Stats home screen widget

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AppInsightsSettings">
+    <option name="tabSettings">
+      <map>
+        <entry key="Firebase Crashlytics">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="PLACEHOLDER" />
+                  <option name="mobileSdkAppId" value="" />
+                  <option name="projectId" value="" />
+                  <option name="projectNumber" value="" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="THIRTY_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-10-18T19:34:03.968625582Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=RZCY41MDQ7E" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,18 @@
         android:theme="@style/Theme.AndroidManager"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
+        <receiver
+            android:name=".widget.SystemStatsWidgetReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/system_stats_widget_info" />
+        </receiver>
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/sp45/androidmanager/widget/SystemStatsWidget.kt
+++ b/app/src/main/java/com/sp45/androidmanager/widget/SystemStatsWidget.kt
@@ -1,0 +1,204 @@
+package com.sp45.androidmanager.widget
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.Serializer
+import androidx.datastore.dataStore
+import androidx.datastore.dataStoreFile
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.LinearProgressIndicator
+import androidx.glance.appwidget.provideContent
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.glance.background
+import androidx.glance.currentState
+import androidx.glance.state.GlanceStateDefinition
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import com.google.gson.Gson
+import com.sp45.androidmanager.domain.repository.SystemStatsRepository
+import dagger.hilt.android.AndroidEntryPoint
+import java.io.InputStream
+import java.io.OutputStream
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.width
+import java.io.File
+
+data class SystemStatsInfo(
+    val cpuProgress: Float = 0.0f,
+    val memoryProgress: Float = 0.0f,
+    val batteryProgress: Float = 0.0f,
+    val storageProgress: Float = 0.0f,
+    val networkValue: String = "--"
+)
+
+object SystemStatsSerializer : Serializer<SystemStatsInfo> {
+    private val gson = Gson()
+    override val defaultValue: SystemStatsInfo = SystemStatsInfo()
+
+    override suspend fun readFrom(input: InputStream): SystemStatsInfo {
+        return gson.fromJson(input.reader(), SystemStatsInfo::class.java)
+    }
+
+    override suspend fun writeTo(t: SystemStatsInfo, output: OutputStream) {
+        output.writer().use {
+            gson.toJson(t, it)
+        }
+    }
+}
+
+object SystemStatsStateDefinition : GlanceStateDefinition<SystemStatsInfo> {
+    private const val DATA_STORE_FILE_NAME = "system_stats_widget"
+    private val Context.systemStatsDataStore by dataStore(
+        fileName = DATA_STORE_FILE_NAME,
+        serializer = SystemStatsSerializer
+    )
+
+    override suspend fun getDataStore(context: Context, fileKey: String): DataStore<SystemStatsInfo> {
+        return context.systemStatsDataStore
+    }
+
+    override fun getLocation(context: Context, fileKey: String): File {
+        return context.dataStoreFile(DATA_STORE_FILE_NAME)
+    }
+}
+
+class SystemStatsWidget : GlanceAppWidget() {
+    override val stateDefinition: GlanceStateDefinition<SystemStatsInfo> = SystemStatsStateDefinition
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        provideContent {
+            GlanceTheme {
+                Content(currentState())
+            }
+        }
+    }
+
+    @Composable
+    fun Content(stats: SystemStatsInfo) {
+        Column(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(GlanceTheme.colors.surface)
+                .padding(16.dp),
+            verticalAlignment = Alignment.Vertical.Top,
+            horizontalAlignment = Alignment.Horizontal.Start
+        ) {
+            Text("System Stats", style = TextStyle(color = GlanceTheme.colors.onSurface))
+            Spacer(modifier = GlanceModifier.height(16.dp))
+            StatRow(label = "CPU", progress = stats.cpuProgress)
+            Spacer(modifier = GlanceModifier.height(8.dp))
+            StatRow(label = "Memory", progress = stats.memoryProgress)
+            Spacer(modifier = GlanceModifier.height(8.dp))
+            StatRow(label = "Battery", progress = stats.batteryProgress)
+            Spacer(modifier = GlanceModifier.height(8.dp))
+            StatRow(label = "Storage", progress = stats.storageProgress)
+            Spacer(modifier = GlanceModifier.height(8.dp))
+            ValueRow(label = "Net Rx", value = stats.networkValue)
+        }
+    }
+
+    @Composable
+    private fun StatRow(label: String, progress: Float) {
+        Row(
+            modifier = GlanceModifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Vertical.CenterVertically
+        ) {
+            Text(
+                text = label,
+                modifier = GlanceModifier.width(64.dp),
+                style = TextStyle(color = GlanceTheme.colors.onSurface)
+            )
+            LinearProgressIndicator(
+                progress = progress,
+                modifier = GlanceModifier.defaultWeight()
+            )
+            Text(
+                text = "${(progress * 100).toInt()}%",
+                modifier = GlanceModifier.padding(start = 8.dp),
+                style = TextStyle(color = GlanceTheme.colors.onSurface)
+            )
+        }
+    }
+
+    @Composable
+    private fun ValueRow(label: String, value: String) {
+        Row(
+            modifier = GlanceModifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Vertical.CenterVertically
+        ) {
+            Text(
+                text = label,
+                modifier = GlanceModifier.width(64.dp),
+                style = TextStyle(color = GlanceTheme.colors.onSurface)
+            )
+            Text(
+                text = value,
+                modifier = GlanceModifier.defaultWeight(),
+                style = TextStyle(color = GlanceTheme.colors.onSurface)
+            )
+        }
+    }
+}
+
+@AndroidEntryPoint
+class SystemStatsWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = SystemStatsWidget()
+
+    @Inject
+    lateinit var repository: SystemStatsRepository
+
+    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var dataCollectionJob: Job? = null
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        if (dataCollectionJob?.isActive == true) return
+
+        dataCollectionJob = coroutineScope.launch {
+            val glanceAppWidgetManager = GlanceAppWidgetManager(context)
+            repository.getLatestStatsFlow().collect { entity ->
+                entity?.let {
+                    val info = SystemStatsInfo(
+                        cpuProgress = (it.cpuSystemLoad / 100.0).toFloat(),
+                        memoryProgress = (it.memUsedMB.toFloat() / it.memTotalMB.toFloat()),
+                        batteryProgress = (it.batteryLevelPct / 100.0).toFloat(),
+                        storageProgress = (1.0f - (it.storageInternalFreeGB.toFloat() / it.storageInternalTotalGB.toFloat())),
+                        networkValue = "${it.networkTotalRxMB} MB"
+                    )
+
+                    val glanceIds = glanceAppWidgetManager.getGlanceIds(SystemStatsWidget::class.java)
+                    glanceIds.forEach { glanceId ->
+                        updateAppWidgetState(context, SystemStatsStateDefinition, glanceId) { info }
+                        glanceAppWidget.update(context, glanceId)
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onDisabled(context: Context) {
+        dataCollectionJob?.cancel()
+        dataCollectionJob = null
+        super.onDisabled(context)
+    }
+}

--- a/app/src/main/res/layout/system_stats_widget_preview.xml
+++ b/app/src/main/res/layout/system_stats_widget_preview.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="System Stats" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">DroidManager</string>
+    <string name="system_stats_widget_description">Displays system statistics like CPU and Memory usage.</string>
 </resources>

--- a/app/src/main/res/xml/system_stats_widget_info.xml
+++ b/app/src/main/res/xml/system_stats_widget_info.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="60dp"
+    android:updatePeriodMillis="86400000"
+    android:previewImage="@drawable/ic_launcher_foreground"
+    android:initialLayout="@layout/system_stats_widget_preview"
+    android:description="@string/system_stats_widget_description"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.0-alpha02"
+agp = "8.10.1"
 glanceAppwidget = "1.1.1"
 kotlin = "2.2.0"
 coreKtx = "1.16.0"


### PR DESCRIPTION
This PR introduces a new SystemStatsWidget built with Jetpack Glance to display real-time system metrics on the user's home screen.

It leverages Hilt for dependency injection, Flow for live data updates from the repository, and DataStore to persist the widget's state efficiently.

Changes:

- SystemStatsWidget: A new Glance widget to display CPU, Memory, Battery, and Storage stats.
- SystemStatsWidgetReceiver: Manages the widget's lifecycle, collecting data from SystemStatsRepository and triggering UI updates.
- SystemStatsStateDefinition: Handles state persistence using DataStore.

The widget starts collecting data when placed on the screen and stops when removed to conserve resources.

**Widget Preview**
<img width="1080" height="2424" alt="AddIcon" src="https://github.com/user-attachments/assets/0c4356e9-e2ba-43c5-858f-ac8a20e776d9" />


<img width="1080" height="2424" alt="HomeScreenWidget" src="https://github.com/user-attachments/assets/f543da6a-01a1-4578-a0a6-c6cdad7c148b" />




